### PR TITLE
VS14 wants /DLL in link command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,7 @@ def main():
                                 '"/D _MBCS"', '/GF', '/Gm', '/Zi', '/EHsc',
                                 '/MT', '/Gy', '/W4', '/nologo', '/c', '/TC',
                                 '/Fdbuild\\vc90.pdb'],
-            extra_link_args=['/MANIFEST']))]
+            extra_link_args=['/MANIFEST', '/DLL']))]
     elif 'darwin' in system or 'macosx' in system:
         libraries = [(
             'distorm3', dict(


### PR DESCRIPTION
Without it, Visual Studio 14.0 (also command-line only Microsoft Visual C++ Build Tools) reports "LINK : fatal error LNK1561: entry point must be defined" and fails to link.
